### PR TITLE
added trusted ssh ranges with env

### DIFF
--- a/.github/workflows/pulumi.deploy.yml
+++ b/.github/workflows/pulumi.deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - feat/*
+      - feature/*
   pull_request:
     branches:
       - main
@@ -58,6 +60,6 @@ jobs:
       - name: Pulumi Preview
         run: pulumi preview
 
-      - name: Pulumi Deploy (only on push to main)
-        if: github.event_name == 'push'
+      - name: Pulumi Deploy (only on push to main) # push and branch to main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: pulumi up --yes

--- a/.github/workflows/pulumi.deploy.yml
+++ b/.github/workflows/pulumi.deploy.yml
@@ -13,6 +13,7 @@ env:
   STACK_NAME: dev
   REGION: us-central1
   PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+  VPC_SSH_SOURCE_RANGE: ${{ secrets.MY_HOME_IP }}/32
 
 
 jobs:

--- a/index.ts
+++ b/index.ts
@@ -3,29 +3,29 @@ import { VPC } from "./modules/vpc";
 
 // Retrieve the source ranges and subnets configuration securely
 const subnetsConfigIndiaVPC = [
-    {
-        cidrRange: process.env.VPC_CIDR_RANGE_1 || "10.0.0.0/16",
-        name: "vpc-subnet-1",
-    },
-    {
-        cidrRange: process.env.VPC_CIDR_RANGE_2 || "10.1.0.0/16",
-        name: "vpc-subnet-2",
-    },
+  {
+    cidrRange: process.env.VPC_CIDR_RANGE_1 || "10.0.0.0/16",
+    name: "vpc-subnet-1",
+  },
+  {
+    cidrRange: process.env.VPC_CIDR_RANGE_2 || "10.1.0.0/16",
+    name: "vpc-subnet-2",
+  },
 ];
 
 // Use environment variables for source ranges
 const sourceRangesIndiaVPC = [process.env.VPC_SOURCE_RANGE || "10.0.0.0/8"];
 const sshSourceRangesIndiaVPC = [
-    process.env.VPC_SSH_SOURCE_RANGE || "0.0.0.0/0",
+  process.env.VPC_SSH_SOURCE_RANGE || "0.0.0.0/0",
 ];
 
 // Create VPC instances
 const indiaVPC = new VPC(
-    "india-vpc",
-    process.env.GCP_REGION || "us-central1",
-    subnetsConfigIndiaVPC,
-    sourceRangesIndiaVPC,
-    sshSourceRangesIndiaVPC
+  "india-vpc",
+  process.env.GCP_REGION || "us-central1",
+  subnetsConfigIndiaVPC,
+  sourceRangesIndiaVPC,
+  sshSourceRangesIndiaVPC
 );
 
 // Export the VPC details

--- a/index.ts
+++ b/index.ts
@@ -9,9 +9,10 @@ const subnetsConfigIndiaVPC = [
 
 // Use environment variables for source ranges
 const sourceRangesIndiaVPC = [process.env.VPC_SOURCE_RANGE || "10.0.0.0/8"];
+const sshSourceRangesIndiaVPC = [process.env.VPC_SSH_SOURCE_RANGE || "0.0.0.0/0"];
 
 // Create VPC instances
-const indiaVPC = new VPC("india-vpc", process.env.GCP_REGION || "us-central1", subnetsConfigIndiaVPC, sourceRangesIndiaVPC);
+const indiaVPC = new VPC("india-vpc", process.env.GCP_REGION || "us-central1", subnetsConfigIndiaVPC, sourceRangesIndiaVPC, sshSourceRangesIndiaVPC);
 
 // Export the VPC details
 export const indiaVpcDetails = indiaVPC.getVPCDetails();

--- a/index.ts
+++ b/index.ts
@@ -3,16 +3,30 @@ import { VPC } from "./modules/vpc";
 
 // Retrieve the source ranges and subnets configuration securely
 const subnetsConfigIndiaVPC = [
-    { cidrRange: process.env.VPC_CIDR_RANGE_1 || "10.0.0.0/16", name: "vpc-subnet-1" },
-    { cidrRange: process.env.VPC_CIDR_RANGE_2 || "10.1.0.0/16", name: "vpc-subnet-2" },
+    {
+        cidrRange: process.env.VPC_CIDR_RANGE_1 || "10.0.0.0/16",
+        name: "vpc-subnet-1",
+    },
+    {
+        cidrRange: process.env.VPC_CIDR_RANGE_2 || "10.1.0.0/16",
+        name: "vpc-subnet-2",
+    },
 ];
 
 // Use environment variables for source ranges
 const sourceRangesIndiaVPC = [process.env.VPC_SOURCE_RANGE || "10.0.0.0/8"];
-const sshSourceRangesIndiaVPC = [process.env.VPC_SSH_SOURCE_RANGE || "0.0.0.0/0"];
+const sshSourceRangesIndiaVPC = [
+    process.env.VPC_SSH_SOURCE_RANGE || "0.0.0.0/0",
+];
 
 // Create VPC instances
-const indiaVPC = new VPC("india-vpc", process.env.GCP_REGION || "us-central1", subnetsConfigIndiaVPC, sourceRangesIndiaVPC, sshSourceRangesIndiaVPC);
+const indiaVPC = new VPC(
+    "india-vpc",
+    process.env.GCP_REGION || "us-central1",
+    subnetsConfigIndiaVPC,
+    sourceRangesIndiaVPC,
+    sshSourceRangesIndiaVPC
+);
 
 // Export the VPC details
 export const indiaVpcDetails = indiaVPC.getVPCDetails();

--- a/modules/vpc.ts
+++ b/modules/vpc.ts
@@ -23,7 +23,7 @@ export class VPC {
      * @param region The region where the VPC will be created.
      * @param subnetsConfig Array of subnet configurations with CIDR range and name.
      */
-    constructor(name: string, region: string, subnetsConfig: { cidrRange: string; name: string }[], sourceRanges: string[]) {
+    constructor(name: string, region: string, subnetsConfig: { cidrRange: string; name: string }[], sourceRanges: string[], sshSourceRanges: string[]) {
         // Create the VPC network
         this.vpc = new gcp.compute.Network(name, {
             autoCreateSubnetworks: false, // Disable auto subnet creation for custom subnets
@@ -42,7 +42,7 @@ export class VPC {
         });
 
         // Implement basic firewall rules for SOC2 compliance
-        this.createFirewallRules(sourceRanges);
+        this.createFirewallRules(sourceRanges, sshSourceRanges);
     }
 
     /**
@@ -51,7 +51,7 @@ export class VPC {
      * - Restricts access to the VPC based on IP ranges and specific ports.
      * - Logs all network traffic for auditing purposes.
      */
-    private createFirewallRules(sourceRanges: string[]) {
+    private createFirewallRules(sourceRanges: string[], sshSourceRanges: string[]) {
         // Allow internal traffic within the VPC (for communication between VMs and services)
         new gcp.compute.Firewall("allow-internal", {
             network: this.vpc.id,
@@ -72,7 +72,7 @@ export class VPC {
         new gcp.compute.Firewall("allow-ssh", {
             network: this.vpc.id,
             allows: [{ protocol: "tcp", ports: ["22"] }],
-            sourceRanges: ["YOUR_TRUSTED_IP_RANGE"], // Specify the trusted IP ranges
+            sourceRanges: sshSourceRanges, // Specify the trusted IP ranges
             direction: "INGRESS",
             logConfig: {
                 metadata: "INCLUDE_ALL_METADATA", // Include all metadata for logging

--- a/modules/vpc.ts
+++ b/modules/vpc.ts
@@ -18,12 +18,18 @@ export class VPC {
 
     /**
      * Constructor to create a VPC with multiple subnets.
-     * 
+     *
      * @param name The name of the VPC.
      * @param region The region where the VPC will be created.
      * @param subnetsConfig Array of subnet configurations with CIDR range and name.
      */
-    constructor(name: string, region: string, subnetsConfig: { cidrRange: string; name: string }[], sourceRanges: string[], sshSourceRanges: string[]) {
+    constructor(
+        name: string,
+        region: string,
+        subnetsConfig: { cidrRange: string; name: string }[],
+        sourceRanges: string[],
+        sshSourceRanges: string[]
+    ) {
         // Create the VPC network
         this.vpc = new gcp.compute.Network(name, {
             autoCreateSubnetworks: false, // Disable auto subnet creation for custom subnets
@@ -47,11 +53,14 @@ export class VPC {
 
     /**
      * Creates firewall rules based on best practices for SOC2 compliance.
-     * 
+     *
      * - Restricts access to the VPC based on IP ranges and specific ports.
      * - Logs all network traffic for auditing purposes.
      */
-    private createFirewallRules(sourceRanges: string[], sshSourceRanges: string[]) {
+    private createFirewallRules(
+        sourceRanges: string[],
+        sshSourceRanges: string[]
+    ) {
         // Allow internal traffic within the VPC (for communication between VMs and services)
         new gcp.compute.Firewall("allow-internal", {
             network: this.vpc.id,
@@ -84,11 +93,11 @@ export class VPC {
 
     /**
      * Export VPC and Subnet details.
-     * 
+     *
      * @returns The VPC and Subnet details, including the IDs and names.
      */
     getVPCDetails() {
-        const subnetDetails = this.subnets.map(subnet => ({
+        const subnetDetails = this.subnets.map((subnet) => ({
             subnetName: subnet.name,
             subnetId: subnet.id,
         }));


### PR DESCRIPTION
## Summary by Sourcery

Add separate configuration for SSH source ranges in VPC firewall rules.

Enhancements:
- Update the VPC module to accept and apply specific source IP ranges for SSH access.
- Load SSH source ranges from the `VPC_SSH_SOURCE_RANGE` environment variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for configuring trusted IP ranges for SSH access to the VPC using an environment variable.
- **Refactor**
	- Improved readability of subnet configuration formatting.
	- Updated VPC setup to allow specifying SSH source ranges as a parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->